### PR TITLE
Bumping the default database size to 100 (GP2 recommended minimum)

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -410,8 +410,8 @@ variable "db_storage_size" {
   description = "Size of the database storage in Gigabytes"
   type        = string
 
-  # 20 is the minimum
-  default = 20
+  # 100 is the recommended AWS minimum
+  default = 100
 }
 
 variable "db_storage_type" {


### PR DESCRIPTION
Per AWS guidance for default database sizes on GP2 to prevent IOP bursting issues.

![Screen Shot 2019-11-25 at 1 57 46 PM](https://user-images.githubusercontent.com/671054/69581757-eb410880-0f8b-11ea-8130-6653bdbfaa9e.png)
