### PR TITLE
Optional EC2 Key Name

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -187,6 +187,8 @@ variable "ec2_root_volume_type" {
 variable "ec2_key_name" {
   description = "AWS SSH Key"
   type        = string
+  
+  default     = ""
 }
 
 variable "asg_max_size" {


### PR DESCRIPTION
Adding a default value to `ec2_key_name` effectively making it optional. Validated functionality by passing in the variable and setting it to a blank (same as the proposed default).

Use case: Using SSM for SSH access with the desire to black box the instances otherwise.