### PR TITLE
Fixes issue #21 for enabling terraform destroy and also specifying final snapshot for rds

### DIFF
--- a/README.md
+++ b/README.md
@@ -863,6 +863,17 @@ n/a</td>
 n/a</td>
 <td>yes</td>
 </tr>
+<tr>
+<td>db_final_snapshot_identifier</td>
+<td>If specified a final snapshot will be made of the RDS instance. If left blank, the finalsnapshot will be skipped</td>
+<td>
+
+`string`</td>
+<td>
+
+""</td>
+<td>no</td>
+</tr>
 </table>
 
 Note: Admin, manager, and portal are Enterprise features. While the SSL

--- a/rds.tf
+++ b/rds.tf
@@ -1,5 +1,5 @@
 resource "aws_db_instance" "kong" {
-  count = local.enable_rds ? 1 : 0
+  count      = local.enable_rds ? 1 : 0
   identifier = format("%s-%s", var.service, var.environment)
 
 
@@ -20,9 +20,9 @@ resource "aws_db_instance" "kong" {
 
   vpc_security_group_ids = [aws_security_group.postgresql.id]
 
-  skip_final_snapshot = var.db_final_snapshot_identifier == "" ? true : false
+  skip_final_snapshot       = var.db_final_snapshot_identifier == "" ? true : false
   final_snapshot_identifier = var.db_final_snapshot_identifier == "" ? null : var.db_final_snapshot_identifier
-  
+
   tags = merge(
     {
       "Name"        = format("%s-%s", var.service, var.environment),

--- a/rds.tf
+++ b/rds.tf
@@ -32,6 +32,7 @@ resource "aws_db_instance" "kong" {
     },
     var.tags
   )
+  depends_on = [aws_db_parameter_group.kong]
 }
 
 resource "aws_db_parameter_group" "kong" {

--- a/rds.tf
+++ b/rds.tf
@@ -1,6 +1,5 @@
 resource "aws_db_instance" "kong" {
   count = local.enable_rds ? 1 : 0
-
   identifier = format("%s-%s", var.service, var.environment)
 
 
@@ -21,6 +20,9 @@ resource "aws_db_instance" "kong" {
 
   vpc_security_group_ids = [aws_security_group.postgresql.id]
 
+  skip_final_snapshot = var.db_final_snapshot_identifier == "" ? true : false
+  final_snapshot_identifier = var.db_final_snapshot_identifier == "" ? null : var.db_final_snapshot_identifier
+  
   tags = merge(
     {
       "Name"        = format("%s-%s", var.service, var.environment),

--- a/redis.tf
+++ b/redis.tf
@@ -23,6 +23,7 @@ resource "aws_elasticache_replication_group" "kong" {
     },
     var.tags
   )
+  depends_on = [aws_elasticache_parameter_group.kong]
 }
 
 resource "aws_elasticache_parameter_group" "kong" {

--- a/variables.tf
+++ b/variables.tf
@@ -516,7 +516,7 @@ variable "deck_version" {
 }
 
 variable "db_final_snapshot_identifier" {
-  description = "identifier"
+  description = "The final snapshot name of the RDS instance when it gets destroyed"
   type = string
   default = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -515,3 +515,8 @@ variable "deck_version" {
   default = "1.0.0"
 }
 
+variable "db_final_snapshot_identifier" {
+  description = "identifier"
+  type = string
+  default = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -517,6 +517,6 @@ variable "deck_version" {
 
 variable "db_final_snapshot_identifier" {
   description = "The final snapshot name of the RDS instance when it gets destroyed"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }


### PR DESCRIPTION
Creating db_final_snapshot_identifier variable and including it in rds.tf. This will make it possible to use the terraform destroy command against this module (#21)