### PR TITLE
 Update Kong and decK to latest version, fix Kong download link, other minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -871,7 +871,7 @@ n/a</td>
 </tr>
 <tr>
 <td>db_final_snapshot_identifier</td>
-<td>If specified a final snapshot will be made of the RDS instance. If left blank, the finalsnapshot will be skipped</td>
+<td>If specified a final snapshot will be made of the RDS/Aurora instance. If left blank, the finalsnapshot will be skipped</td>
 <td>
 
 `string`</td>

--- a/aurora.tf
+++ b/aurora.tf
@@ -14,6 +14,9 @@ resource "aws_rds_cluster" "kong" {
 
   vpc_security_group_ids = [aws_security_group.postgresql.id]
 
+  skip_final_snapshot       = var.db_final_snapshot_identifier == "" ? true : false
+  final_snapshot_identifier = var.db_final_snapshot_identifier == "" ? null : var.db_final_snapshot_identifier
+
   tags = merge(
     {
       "Name"        = format("%s-%s", var.service, var.environment),

--- a/cloud-init.cfg
+++ b/cloud-init.cfg
@@ -42,3 +42,4 @@ packages:
   - perl
   - libpcre3
   - awscli
+  - zlib1g-dev

--- a/cloud-init.sh
+++ b/cloud-init.sh
@@ -29,7 +29,7 @@ echo "Installing Kong"
 EE_LICENSE=$(aws_get_parameter ee/license)
 EE_CREDS=$(aws_get_parameter ee/bintray-auth)
 if [ "$EE_LICENSE" != "placeholder" ]; then
-    curl -sL https://kong.bintray.com/kong-enterprise-edition-deb/dists/${EE_PKG} \
+    curl -sL "https://download.konghq.com/gateway-2.x-ubuntu-bionic/pool/all/k/kong-enterprise-edition/${EE_PKG}" \
         -u $EE_CREDS \
         -o ${EE_PKG} 
 
@@ -45,7 +45,7 @@ EOF
     chown root:kong /etc/kong/license.json
     chmod 640 /etc/kong/license.json
 else  
-    curl -sL "https://bintray.com/kong/kong-deb/download_file?file_path=${CE_PKG}" \
+    curl -sL "https://download.konghq.com/gateway-2.x-ubuntu-bionic/pool/all/k/kong/${CE_PKG}" \
         -o ${CE_PKG}
     dpkg -i ${CE_PKG}
 fi

--- a/cloud-init.sh
+++ b/cloud-init.sh
@@ -194,9 +194,9 @@ cat <<'EOF' > /etc/logrotate.d/kong
 EOF
 
 # Additional environment variables
-cat <<EOF >> /etc/environment
-DECK_REDIS_HOST=$(aws_get_parameter redis/primary-endpoint)
-EOF
+# cat <<EOF >> /etc/environment
+# DECK_REDIS_HOST=$(aws_get_parameter redis/primary-endpoint)
+# EOF
 
 # Start Kong under supervision
 echo "Starting Kong under supervision"

--- a/cloud-init.sh
+++ b/cloud-init.sh
@@ -81,6 +81,8 @@ fi
 unset PGPASSWORD
 
 # Setup Configuration file
+mkdir -p /etc/kong
+
 cat <<EOF > /etc/kong/kong.conf
 # kong.conf, Kong configuration file
 # Written by Dennis Kelly <dennisk@zillowgroup.com>
@@ -139,7 +141,7 @@ EOF
     done
 else
     # CE does not create the kong directory
-    mkdir /usr/local/kong
+    mkdir -p /usr/local/kong
 fi
 
 chown root:kong /usr/local/kong

--- a/cloud-init.sh
+++ b/cloud-init.sh
@@ -193,6 +193,11 @@ cat <<'EOF' > /etc/logrotate.d/kong
 }
 EOF
 
+# Additional environment variables
+cat <<EOF >> /etc/environment
+DECK_REDIS_HOST=$(aws_get_parameter redis/primary-endpoint)
+EOF
+
 # Start Kong under supervision
 echo "Starting Kong under supervision"
 mkdir -p /etc/sv/kong /etc/sv/kong/log

--- a/cloud-init.tf
+++ b/cloud-init.tf
@@ -1,16 +1,16 @@
 locals {
-    render_variables = {
-        DB_USER        = replace(format("%s_%s", var.service, var.environment), "-", "_")
-        CE_PKG         = var.ce_pkg
-        EE_PKG         = var.ee_pkg
-        PARAMETER_PATH = format("/%s/%s", var.service, var.environment)
-        REGION         = data.aws_region.current.name
-        VPC_CIDR_BLOCK = data.aws_vpc.vpc.cidr_block
-        DECK_VERSION   = var.deck_version
-        MANAGER_HOST   = local.manager_host
-        PORTAL_HOST    = local.portal_host
-        SESSION_SECRET = random_string.session_secret.result
-    }
+  render_variables = {
+    DB_USER        = replace(format("%s_%s", var.service, var.environment), "-", "_")
+    CE_PKG         = var.ce_pkg
+    EE_PKG         = var.ee_pkg
+    PARAMETER_PATH = format("/%s/%s", var.service, var.environment)
+    REGION         = data.aws_region.current.name
+    VPC_CIDR_BLOCK = data.aws_vpc.vpc.cidr_block
+    DECK_VERSION   = var.deck_version
+    MANAGER_HOST   = local.manager_host
+    PORTAL_HOST    = local.portal_host
+    SESSION_SECRET = random_string.session_secret.result
+  }
 }
 
 data "cloudinit_config" "cloud-init" {

--- a/cloud-init.tf
+++ b/cloud-init.tf
@@ -1,36 +1,30 @@
-data "template_file" "cloud-init" {
-  template = file("${path.module}/cloud-init.cfg")
+locals {
+    render_variables = {
+        DB_USER        = replace(format("%s_%s", var.service, var.environment), "-", "_")
+        CE_PKG         = var.ce_pkg
+        EE_PKG         = var.ee_pkg
+        PARAMETER_PATH = format("/%s/%s", var.service, var.environment)
+        REGION         = data.aws_region.current.name
+        VPC_CIDR_BLOCK = data.aws_vpc.vpc.cidr_block
+        DECK_VERSION   = var.deck_version
+        MANAGER_HOST   = local.manager_host
+        PORTAL_HOST    = local.portal_host
+        SESSION_SECRET = random_string.session_secret.result
+    }
 }
 
-data "template_file" "shell-script" {
-  template = file("${path.module}/cloud-init.sh")
-
-  vars = {
-    DB_USER        = replace(format("%s_%s", var.service, var.environment), "-", "_")
-    CE_PKG         = var.ce_pkg
-    EE_PKG         = var.ee_pkg
-    PARAMETER_PATH = format("/%s/%s", var.service, var.environment)
-    REGION         = data.aws_region.current.name
-    VPC_CIDR_BLOCK = data.aws_vpc.vpc.cidr_block
-    DECK_VERSION   = var.deck_version
-    MANAGER_HOST   = local.manager_host
-    PORTAL_HOST    = local.portal_host
-    SESSION_SECRET = random_string.session_secret.result
-  }
-}
-
-data "template_cloudinit_config" "cloud-init" {
+data "cloudinit_config" "cloud-init" {
   gzip          = true
   base64_encode = true
 
   part {
     filename     = "init.cfg"
     content_type = "text/cloud-config"
-    content      = data.template_file.cloud-init.rendered
+    content      = file("${path.module}/cloud-init.cfg")
   }
 
   part {
     content_type = "text/x-shellscript"
-    content      = data.template_file.shell-script.rendered
+    content      = templatefile("${path.module}/cloud-init.sh", local.render_variables)
   }
 }

--- a/cw.tf
+++ b/cw.tf
@@ -13,7 +13,7 @@ module "kong_external_lb_cw" {
 module "kong_internal_lb_cw" {
   source = "./cw/lb"
 
-  enable        = var.enable_external_lb
+  enable        = var.enable_internal_lb
   load_balancer = coalesce(join("", aws_lb.internal.*.arn_suffix), "none")
   target_group  = coalesce(join("", aws_lb_target_group.internal.*.arn), "none")
 

--- a/ec2.tf
+++ b/ec2.tf
@@ -82,6 +82,7 @@ resource "aws_autoscaling_group" "kong" {
 
   depends_on = [
     aws_db_instance.kong,
-    aws_rds_cluster.kong
+    aws_rds_cluster.kong,
+    aws_elasticache_replication_group.kong
   ]
 }

--- a/ec2.tf
+++ b/ec2.tf
@@ -13,7 +13,7 @@ resource "aws_launch_configuration" "kong" {
   associate_public_ip_address = false
   enable_monitoring           = true
   placement_tenancy           = "default"
-  user_data                   = data.template_cloudinit_config.cloud-init.rendered
+  user_data                   = data.cloudinit_config.cloud-init.rendered
 
   root_block_device {
     volume_size = var.ec2_root_volume_size

--- a/rds.tf
+++ b/rds.tf
@@ -12,7 +12,7 @@ resource "aws_db_instance" "kong" {
   backup_retention_period = var.db_backup_retention_period
   db_subnet_group_name    = var.db_subnets
   multi_az                = var.db_multi_az
-  parameter_group_name    = format("%s-%s", var.service, var.environment)
+  parameter_group_name    = var.db_instance_count > 0 ? aws_db_parameter_group.kong[0].name : format("%s-%s", var.service, var.environment)
 
 
   username = "root"
@@ -32,7 +32,6 @@ resource "aws_db_instance" "kong" {
     },
     var.tags
   )
-  depends_on = [aws_db_parameter_group.kong]
 }
 
 resource "aws_db_parameter_group" "kong" {

--- a/ssm.tf
+++ b/ssm.tf
@@ -96,3 +96,12 @@ resource "aws_ssm_parameter" "db-master-password" {
 
   overwrite = true
 }
+
+resource "aws_ssm_parameter" "redis-primary-endpoint" {
+  name = format("/%s/%s/redis/primary-endpoint", var.service, var.environment)
+  type = "String"
+  value = coalesce(
+    join("", aws_elasticache_replication_group.kong.*.primary_endpoint_address),
+    "none"
+  )
+}

--- a/variables.tf
+++ b/variables.tf
@@ -518,7 +518,7 @@ variable "deck_version" {
 }
 
 variable "db_final_snapshot_identifier" {
-  description = "The final snapshot name of the RDS instance when it gets destroyed"
+  description = "The final snapshot name of the RDS/Aurora instance when it gets destroyed"
   type        = string
   default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -239,14 +239,14 @@ variable "ee_pkg" {
   description = "Filename of the Enterprise Edition package"
   type        = string
 
-  default = "kong-enterprise-edition-1.3.0.1.bionic.all.deb "
+  default = "kong-enterprise-edition_2.6.0.0_all.deb"
 }
 
 variable "ce_pkg" {
   description = "Filename of the Community Edition package"
   type        = string
 
-  default = "kong-1.5.0.bionic.amd64.deb"
+  default = "kong_2.6.0_amd64.deb"
 }
 
 # Load Balancer settings

--- a/variables.tf
+++ b/variables.tf
@@ -514,7 +514,7 @@ variable "deck_version" {
   description = "Version of decK to install"
   type        = string
 
-  default = "1.0.0"
+  default = "1.8.2"
 }
 
 variable "db_final_snapshot_identifier" {


### PR DESCRIPTION
Hi

This PR contains the following changes:
1. Update Kong to 2.6.0
2. Fix link to download Kong from bintray the the official location
3. Update decK to latest version
4. Expose hostname for redis instance as an environment variable so it can be used in deck configurations
5. Fix random issue due to directory /etc/kong not existing in the container.
6. Fix private load balancer using the configuration for the public one.