### PR TITLE
line 12 update

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -9,7 +9,7 @@ data "aws_vpc" "vpc" {
 
 data "aws_region" "current" {}
 
-data "aws_subnet_ids" "public" {
+data "aws_subnets" "public" {
   vpc_id = data.aws_vpc.vpc.id
 
   filter {


### PR DESCRIPTION
 with module.kong.data.aws_subnet_ids.public,
│   on .terraform/modules/kong/data.tf line 12, in data "aws_subnet_ids" "public":
│   12: data "aws_subnet_ids" "public" {
│ 
│ The aws_subnet_ids data source has been deprecated and will be removed
│ in a future version. Use the aws_subnets data source instead.
